### PR TITLE
Data to tensor

### DIFF
--- a/Data/LoadData.py
+++ b/Data/LoadData.py
@@ -1,0 +1,47 @@
+import os
+import ember
+import tensorflow as tf
+
+
+def init_vectorized_features(dataset_dir):
+    """
+    Required for the generation of '.dat' data files
+
+    :param dataset_dir: directory to the base location of the dataset
+    :return:
+    """
+    ember.create_vectorized_features(dataset_dir, 1)
+
+
+def dat_to_train_test(dat_dir):
+    """
+    Loading training & testing data from respective generated '.dat' files
+
+    :param dat_dir: directory to the base location where generated '.dat' files are found
+    :return:
+    """
+    try:
+        assert('X_train.dat' in os.listdir(dat_dir))
+        assert('y_train.dat' in os.listdir(dat_dir))
+        assert ('X_test.dat' in os.listdir(dat_dir))
+        assert ('y_test.dat' in os.listdir(dat_dir))
+
+        x_train, y_train = ember.read_vectorized_features(dat_dir, subset="train")
+        x_test, y_test = ember.read_vectorized_features(dat_dir, subset="test")
+
+        return x_train, y_train, x_test, y_test
+    except AssertionError:
+        raise Exception("[ASSERTION ERROR] Ensure that the required '.dat' files are found within the specified directory")
+
+
+# TODO: implement functionality to convert from existing <class 'numpy.memmap'> dtype to tensors
+def to_tensor():
+    """
+
+    :return:
+    """
+    pass
+
+
+if __name__ == '__main__':
+    x_train, y_train, x_test, y_test = dat_to_train_test('./dat')

--- a/Data/LoadData.py
+++ b/Data/LoadData.py
@@ -43,5 +43,6 @@ def to_tensor():
     pass
 
 
+# TODO: remove unlabeled data points from dataset
 if __name__ == '__main__':
     x_train, y_train, x_test, y_test = dat_to_train_test('./dat')

--- a/Data/LoadData.py
+++ b/Data/LoadData.py
@@ -31,18 +31,40 @@ def dat_to_train_test(dat_dir):
 
         return x_train, y_train, x_test, y_test
     except AssertionError:
-        raise Exception("[ASSERTION ERROR] Ensure that the required '.dat' files are found within the specified directory")
+        raise Exception(
+            "[ASSERTION ERROR] Ensure that the required '.dat' files are found within the specified directory"
+        )
 
 
-# TODO: implement functionality to convert from existing <class 'numpy.memmap'> dtype to tensors
-def to_tensor():
+def __dataset_generator(data, labels):
     """
+    Helper function for conversion from numpy.memmap to tf.data.Dataset
+    Create callable generator for tf.data.Dataset.from_generator()
+
+    :param data:
+    :param labels:
+    :return:
+    """
+    # requires nothing to be passed to generator to avoid "TypeError: 'generator' must be callable." error
+    def generator():
+        for instance, label in zip(data, labels):
+            yield instance, label
+    return generator
+
+
+def to_tf_dataset(x_memmap_data, y_memmap_data):
+    """
+    Convert numpy.memmap to tf.data.Dataset via the creation of generator with helper function '__dataset_generator()'
 
     :return:
     """
-    pass
+    return tf.data.Dataset.from_generator(__dataset_generator(x_memmap_data, y_memmap_data),
+                                          output_types=(x_memmap_data.dtype, y_memmap_data.dtype),
+                                          output_shapes=(x_memmap_data.shape, y_memmap_data.shape))
 
 
 # TODO: remove unlabeled data points from dataset
 if __name__ == '__main__':
     x_train, y_train, x_test, y_test = dat_to_train_test('./dat')
+    training_data = to_tf_dataset(x_train, y_train)
+    testing_data = to_tf_dataset(x_test, y_test)

--- a/Data/LoadData.py
+++ b/Data/LoadData.py
@@ -1,19 +1,27 @@
 import os
 import ember
+import numpy as np
 import tensorflow as tf
 
 
-def init_vectorized_features(dataset_dir):
+def init_vectorized_features(dataset_dir: str):
     """
     Required for the generation of '.dat' data files
 
     :param dataset_dir: directory to the base location of the dataset
     :return:
     """
-    ember.create_vectorized_features(dataset_dir, 1)
+    try:
+        assert(os.path.exists(dataset_dir))
+
+        ember.create_vectorized_features(dataset_dir, 1)
+    except AssertionError:
+        raise Exception(
+            "[ASSERTION ERROR] The path to base directory of dataset provided does not exist"
+        )
 
 
-def dat_to_train_test(dat_dir):
+def dat_to_train_test(dat_dir: str):
     """
     Loading training & testing data from respective generated '.dat' files
 
@@ -36,13 +44,13 @@ def dat_to_train_test(dat_dir):
         )
 
 
-def __dataset_generator(data, labels):
+def __dataset_generator(data: np.memmap, labels: np.memmap):
     """
     Helper function for conversion from numpy.memmap to tf.data.Dataset
     Create callable generator for tf.data.Dataset.from_generator()
 
-    :param data:
-    :param labels:
+    :param data: numpy.memmap of training data
+    :param labels: numpy.memmap of labels corresponding to the training data
     :return:
     """
     # requires nothing to be passed to generator to avoid "TypeError: 'generator' must be callable." error
@@ -52,7 +60,7 @@ def __dataset_generator(data, labels):
     return generator
 
 
-def to_tf_dataset(x_memmap_data, y_memmap_data):
+def to_tf_dataset(x_memmap_data: np.memmap, y_memmap_data: np.memmap):
     """
     Convert numpy.memmap to tf.data.Dataset via the creation of generator with helper function '__dataset_generator()'
 
@@ -60,11 +68,38 @@ def to_tf_dataset(x_memmap_data, y_memmap_data):
     """
     return tf.data.Dataset.from_generator(__dataset_generator(x_memmap_data, y_memmap_data),
                                           output_types=(x_memmap_data.dtype, y_memmap_data.dtype),
-                                          output_shapes=(x_memmap_data.shape, y_memmap_data.shape))
+                                          output_shapes=([x_memmap_data.shape[1], ], []))
 
 
-# TODO: remove unlabeled data points from dataset
-if __name__ == '__main__':
+def __unlabelled(data: tf.Tensor, label: tf.Tensor):
+    """
+    Helper function to act as a callable conditional statement for tf.data.Dataset.filter()
+
+    Note: data is an unused parameter but is necessary for the proper functionality of this function
+    (i.e. do not remove)
+
+    :param data: tensor representation of data within the tf.data.Dataset
+    :param label: tensor representation of label for the respective data within tf.data.Dataset
+    :return:
+    """
+    if label == -1.0:
+        return False
+    return True
+
+
+def rm_unlabelled_samples(dataset: tf.data.Dataset):
+    """
+    Filter all unlabelled data instances (label = -1.0) from the tf.data.Dataset passed in as parameter
+
+    :param dataset: dataset in which the unlabelled instances (label = -1.0) are to be filtered out.
+    :return:
+    """
+    return dataset.filter(__unlabelled)
+
+
+'''if __name__ == '__main__':
     x_train, y_train, x_test, y_test = dat_to_train_test('./dat')
-    training_data = to_tf_dataset(x_train, y_train)
-    testing_data = to_tf_dataset(x_test, y_test)
+    unfiltered_train_ds = to_tf_dataset(x_train, y_train)
+    unfiltered_test_ds = to_tf_dataset(x_test, y_test)
+    train_ds = rm_unlabelled_samples(unfiltered_train_ds)
+    test_ds = rm_unlabelled_samples(unfiltered_test_ds)'''

--- a/Data/dataset_info.txt
+++ b/Data/dataset_info.txt
@@ -1,0 +1,8 @@
+X_train.shape = (900000, 2381)
+y_train.shape = (900000, 1)
+
+X_test.shape = (300000, 2381)
+y_train.shape = (300000, 1)
+
+X data is a collection of instances of floating point values indicating 2381 respective file features
+Y data is a collection of instances of integer values (i.e. -1, 0, 1) with respect to


### PR DESCRIPTION
Closes #8

Implements functionality for:
-  Converting downloaded dataset to `.dat` files
-  Loading said `.dat` files to `np.memmap` format
-  Converting respective `np.memmap`s to `tf.data.Dataset` (for training and testing respectively)
-  Filtering out data instances classified as unlabeled